### PR TITLE
Added the ability to pass an extra extends file.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 0.2.3 (unreleased)
 ------------------
 
+- Added the ability to pass an extra extends file.
 - Remove:
     - BUILDOUT_OPT
 

--- a/plock/config.py
+++ b/plock/config.py
@@ -27,9 +27,14 @@ ARG_PARSER.add_argument(
 ARG_PARSER.add_argument(
     "-u", "--unstable", action="store_true", help="latest release")
 
+ARG_PARSER.add_argument(
+    "-e", "--extra", help="extra extends file"
+)
+
 BUILDOUT_CFG = """\
 [buildout]
-extends = %s
+extends =
+    %s
 """
 
 CFG_PARSER = configparser.SafeConfigParser()

--- a/plock/install.py
+++ b/plock/install.py
@@ -45,15 +45,14 @@ class Installer():
                     exit(1)
         return command
 
-    def create_cfg(self):
+    def create_cfg(self, remotes):
         """
         Create Buildout configuration files in self.directory
         """
         buildout_cfg = os.path.join(self.directory, 'buildout.cfg')
         if not os.path.exists(buildout_cfg):
             cfg = open(buildout_cfg, 'w')
-            release_remote = REMOTE_PLONE
-            cfg.write(BUILDOUT_CFG % release_remote)
+            cfg.write(BUILDOUT_CFG % '\n    '.join(remotes))
             cfg.close
         else:
             print "Error: buildout.cfg file already exists."
@@ -106,7 +105,11 @@ class Installer():
 
         self.create_venv()
         self.install_buildout()
-        self.create_cfg()
+
+        if args.extra:
+            self.create_cfg((REMOTE_PLONE, args.extra))
+        else:
+            self.create_cfg((REMOTE_PLONE, ))
 
         if args.add_on:
             print("Installing addons...")

--- a/plock/tests.py
+++ b/plock/tests.py
@@ -1,4 +1,5 @@
 import unittest
+import os.path
 
 
 class PlockTests(unittest.TestCase):
@@ -8,7 +9,14 @@ class PlockTests(unittest.TestCase):
         from tempfile import mkdtemp
         plock = Installer()
         plock.directory = mkdtemp()
-        plock.create_cfg()
+        plock.create_cfg(('one', 'two', 'three'))
+
+        with open(os.path.join(plock.directory, 'buildout.cfg'), 'r') as f:
+            content = f.read()
+
+        self.assertIn('one', content)
+        self.assertIn('two', content)
+        self.assertIn('three', content)
 
     def test_install_plone(self):
         from mock import Mock
@@ -22,6 +30,7 @@ class PlockTests(unittest.TestCase):
         args.list_addons = False
         args.raw = False
         args.write_config = False
+        args.extra = None
         plock.install_plone(args, test=True)
 
     def test_run_buildout(self):


### PR DESCRIPTION
I'd like to use Plock to make it easy to get a project of ours running. I'd like to target Python developers that don't know Plone, so pip is an obvious choice.

The project I'm talking about is https://github.com/Onegov/onegov.municipality and it's a bit of a distribution of sorts with a number of third-party packages which we integrate and pin to specific versions.

Now technically, this would work:

```
plock -a onegov.municipality .
```

But the versions are going to be all over the place and currently it won't even install because of a version conflict.

That's why I extended Plock thusly:

```
plock -a onegov.municipality -e "https://raw.githubusercontent.com/OneGov/onegov.municipality/master/release/latest.cfg" .
```

This adds an extra extends line to the buildout.cfg, below the original line. This essentially overrides all versions in the first extends file and enables us to use Plock.

I'd love to see this feature in Plock. It's not really a big change in the code so I just went ahead and did it. Feel free to ask me for changes or to do this in a smarter way :smile:

Thanks for Plock in any case! I think there are some interesting things that could be done with it.
